### PR TITLE
Fixed Resubmit button

### DIFF
--- a/assemblyline_core/submission_client.py
+++ b/assemblyline_core/submission_client.py
@@ -143,6 +143,9 @@ class SubmissionClient:
                             if os.path.exists(temporary_path):
                                 os.unlink(temporary_path)
 
+            # Clearing runtime_excluded on initial submit or resubmit
+            submission_obj.params.services.runtime_excluded = []
+
             # We should now have all the information we need to construct a submission object
             sub = Submission(dict(
                 archive_ts=now_as_iso(self.config.datastore.ilm.days_until_archive * 24 * 60 * 60),


### PR DESCRIPTION
- Assisted by @cccs-sgaron 
- The Resubmit button now submits to dynamic services such as Cuckoo, as does the Resubmit Dynamic button


- To test, set up an instance of AL, stop the core_al_ui_1 container, run the app.py file in the assemblyline-ui repo, run task_handler, and run the Cuckoo service (make sure the service parameters match that on Staging) and then submit a sample that drops a file that is a file type that is able to be sent to Cuckoo (html, any office doc, ps1, etc)
    - Upon submission, click Resubmit.
    - Once the extracted sample drops a file that is able to be submitted to Cuckoo, select that file and click Resubmit Dynamic
    - Note that the Ignore Dynamic Recursion Prevention state is still maintained since the extracted file is not automatically submitted to Cuckoo


- Addresses: https://cccs.atlassian.net/browse/AL-551