### PR TITLE
Fix for stable tags

### DIFF
--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -99,7 +99,7 @@ def get_latest_tag_for_service(service_config, system_config, logger):
     else:
         tag_name = f"{FRAMEWORK_VERSION}.{SYSTEM_VERSION}.0.{update_channel}0"
         for t in tags:
-            if re.search(f"\d+[.]\d+[.]\d+[.]({update_channel})\d+", t):
+            if re.match(f"({FRAMEWORK_VERSION})[.]({SYSTEM_VERSION})[.]\d+[.]({update_channel})\d+", t):
                 t_version = parse(t.replace(update_channel, ""))
                 if t_version.major == FRAMEWORK_VERSION and t_version.minor == SYSTEM_VERSION and \
                         t_version > parse(tag_name.replace(update_channel, "")):

--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -1,4 +1,5 @@
 import requests
+import re
 import socket
 import string
 
@@ -98,7 +99,7 @@ def get_latest_tag_for_service(service_config, system_config, logger):
     else:
         tag_name = f"{FRAMEWORK_VERSION}.{SYSTEM_VERSION}.0.{update_channel}0"
         for t in tags:
-            if len(t.split(update_channel))==2 and len(t.split(".")) >= 2:
+            if re.search(f"\d+[.]\d+[.]\d+[.]({update_channel})\d+", t):
                 t_version = parse(t.replace(update_channel, ""))
                 if t_version.major == FRAMEWORK_VERSION and t_version.minor == SYSTEM_VERSION and \
                         t_version > parse(tag_name.replace(update_channel, "")):

--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -98,7 +98,7 @@ def get_latest_tag_for_service(service_config, system_config, logger):
     else:
         tag_name = f"{FRAMEWORK_VERSION}.{SYSTEM_VERSION}.0.{update_channel}0"
         for t in tags:
-            if len(t.split(update_channel))==2:
+            if len(t.split(update_channel))==2 and len(t.split(".")) >= 2:
                 t_version = parse(t.replace(update_channel, ""))
                 if t_version.major == FRAMEWORK_VERSION and t_version.minor == SYSTEM_VERSION and \
                         t_version > parse(tag_name.replace(update_channel, "")):

--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -98,7 +98,7 @@ def get_latest_tag_for_service(service_config, system_config, logger):
     else:
         tag_name = f"{FRAMEWORK_VERSION}.{SYSTEM_VERSION}.0.{update_channel}0"
         for t in tags:
-            if update_channel in t:
+            if len(t.split(update_channel))==2:
                 t_version = parse(t.replace(update_channel, ""))
                 if t_version.major == FRAMEWORK_VERSION and t_version.minor == SYSTEM_VERSION and \
                         t_version > parse(tag_name.replace(update_channel, "")):


### PR DESCRIPTION
Replace "update_channel in t" with len(split()) == 2.
If update_channel not in t, len(split()) will be 1 and won't proceed.

Also check for major.minor in tag

![image](https://user-images.githubusercontent.com/62077998/100350937-af82b980-2fb8-11eb-984b-c0bfa8e1ec50.png)
