### PR TITLE
Keep original ts in alert update

### DIFF
--- a/assemblyline_core/alerter/processing.py
+++ b/assemblyline_core/alerter/processing.py
@@ -194,6 +194,9 @@ def perform_alert_update(datastore, logger, alert):
         if old_alert is None:
             raise KeyError(f"{alert_id} is missing from the alert collection.")
 
+        # Ensure alert keeps original timestamp
+        alert['ts'] = old_alert['ts']
+
         # Merge fields...
         merged = {
             x: list(set(old_alert.get('al', {}).get(x, [])).union(set(alert['al'].get(x, [])))) for x in AL_FIELDS

--- a/test/test_alerter.py
+++ b/test/test_alerter.py
@@ -15,7 +15,6 @@ from assemblyline.odm.randomizer import random_model_obj, get_random_tags
 from assemblyline.remote.datatypes import get_client
 from assemblyline.remote.datatypes.queues.named import NamedQueue
 
-
 NUM_SUBMISSIONS = 2
 all_submissions = []
 
@@ -149,3 +148,4 @@ def test_update_single_alert(config, datastore):
     assert updated_alert is not None
 
     assert updated_alert != original_alert
+    assert updated_alert['ts'] == original_alert['ts']


### PR DESCRIPTION
Relating to: [alerter error](https://cccs.atlassian.net/browse/AL-936)

Error seems to be caused by difference of timestamp value between new and old alerts; this should force the new alert to retain the original timestamp in the update.