### PR TITLE
Find the parent before updating

### DIFF
--- a/test/test_alerter.py
+++ b/test/test_alerter.py
@@ -148,4 +148,4 @@ def test_update_single_alert(config, datastore):
     assert updated_alert is not None
 
     assert updated_alert != original_alert
-    assert updated_alert['ts'] == original_alert['ts']
+    assert all([original_alert[x] == updated_alert[x] for x in config.core.alerter.constant_alert_fields])


### PR DESCRIPTION
Solves two problems alerter has:

- Not finding the parent alert in collection (difference in ts of the child affects generate_alert_id() to not match the parent)
- Ensuring constant fields match between the parent and child alerts when updating