### PR TITLE
Force archive access when freshening files, saving results and updating alerts (dev)

### DIFF
--- a/assemblyline_core/alerter/processing.py
+++ b/assemblyline_core/alerter/processing.py
@@ -190,7 +190,7 @@ def perform_alert_update(datastore, logger, alert):
     alert_id = alert.get('alert_id')
 
     with Lock(f"alert-update-{alert_id}", 5):
-        old_alert = datastore.alert.get(alert_id, as_obj=False)
+        old_alert = datastore.alert.get(alert_id, as_obj=False, force_archive_access=True)
         if old_alert is None:
             raise KeyError(f"{alert_id} is missing from the alert collection.")
 
@@ -209,7 +209,7 @@ def perform_alert_update(datastore, logger, alert):
         old_alert = recursive_update(old_alert, alert)
         old_alert['al'] = recursive_update(old_alert['al'], merged)
 
-        datastore.alert.save(alert_id, old_alert)
+        datastore.alert.save(alert_id, old_alert, force_archive_access=True)
 
     logger.info(f"Alert {alert_id} has been updated.")
 

--- a/assemblyline_core/dispatching/client.py
+++ b/assemblyline_core/dispatching/client.py
@@ -255,16 +255,16 @@ class DispatchClient:
         # most distant expiry time to prevent pulling it out from under another submission too early
         if result.is_empty():
             # Empty Result will not be archived therefore result.archive_ts drives their deletion
-            self.ds.emptyresult.save(result_key, {"expiry_ts": result.archive_ts})
+            self.ds.emptyresult.save(result_key, {"expiry_ts": result.archive_ts}, force_archive_access=True)
         else:
             with Lock(f"lock-{result_key}", 5, self.redis):
-                old = self.ds.result.get(result_key)
+                old = self.ds.result.get(result_key, force_archive_access=True)
                 if old:
                     if old.expiry_ts and result.expiry_ts:
                         result.expiry_ts = max(result.expiry_ts, old.expiry_ts)
                     else:
                         result.expiry_ts = None
-                self.ds.result.save(result_key, result)
+                self.ds.result.save(result_key, result, force_archive_access=True)
 
         # Let the logs know we have received a result for this task
         if result.drop_file:

--- a/test/mocking/datastore.py
+++ b/test/mocking/datastore.py
@@ -5,7 +5,8 @@ class MockCollection:
         self.next_searches = []
         self.schema = schema
 
-    def get(self, key, as_obj=True):
+    # noinspection PyUnusedLocal
+    def get(self, key, as_obj=True, force_archive_access=False):
         if key not in self._docs:
             return None
         if not as_obj:
@@ -21,7 +22,8 @@ class MockCollection:
         print('exists', key, self._docs, key in self._docs)
         return key in self._docs
 
-    def save(self, key, doc):
+    # noinspection PyUnusedLocal
+    def save(self, key, doc, force_archive_access=False):
         if not self.schema or isinstance(doc, self.schema):
             self._docs[key] = doc
             return


### PR DESCRIPTION
Fix for AL-994 where duplicated file entries and results can be created because some system components don't have access to the archive.