### PR TITLE
Use UserQuotaTracker to track user submissions

### DIFF
--- a/test/mocking/__init__.py
+++ b/test/mocking/__init__.py
@@ -36,12 +36,18 @@ class RedisTime:
         return time.time(), 0
 
 
+class RedisZPopMin:
+    def __call__(self, key):
+        return 1
+
+
 @pytest.fixture(scope='function')
 def clean_redis():
     if not hasattr(fakeredis.FakeConnection, 'health_check_interval'):
         fakeredis.FakeConnection.health_check_interval = None
     client = fakeredis.FakeRedis()
     client.time = RedisTime()
+    client.zpopmin = RedisZPopMin()
     return client
 
 


### PR DESCRIPTION
Patch dispatcher to use the UserQuotaTracker to track user submission quotas