### PR TITLE
DEV: Pass on logging level from config to services' env

### DIFF
--- a/assemblyline_core/scaler/controllers/kubernetes_ctl.py
+++ b/assemblyline_core/scaler/controllers/kubernetes_ctl.py
@@ -91,7 +91,7 @@ def parse_cpu(string):
 
 
 class KubernetesController(ControllerInterface):
-    def __init__(self, logger, namespace, prefix, priority, labels=None):
+    def __init__(self, logger, namespace, prefix, priority, labels=None, log_level="INFO"):
         # Try loading a kubernetes connection from either the fact that we are running
         # inside of a cluster, or have a config file that tells us how
         try:
@@ -115,6 +115,7 @@ class KubernetesController(ControllerInterface):
         self.prefix = prefix.lower()
         self.priority = priority
         self.logger = logger
+        self.log_level = log_level
         self._labels = labels
         self.apps_api = client.AppsV1Api()
         self.api = client.CoreV1Api()
@@ -295,7 +296,8 @@ class KubernetesController(ControllerInterface):
         environment_variables = [V1EnvVar(name=_e.name, value=_e.value) for _e in container_config.environment]
         environment_variables += [
             V1EnvVar(name='UPDATE_PATH', value=CONTAINER_UPDATE_DIRECTORY),
-            V1EnvVar(name='FILE_UPDATE_DIRECTORY', value=CONTAINER_UPDATE_DIRECTORY)
+            V1EnvVar(name='FILE_UPDATE_DIRECTORY', value=CONTAINER_UPDATE_DIRECTORY),
+            V1EnvVar(name='LOG_LEVEL', value=self.log_level)
         ]
         return [V1Container(
             name=deployment_name,

--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -219,7 +219,7 @@ class ScalerServer(CoreBase):
             self.log.info(f"Loading Kubernetes cluster interface on namespace: {NAMESPACE}")
             self.controller = KubernetesController(logger=self.log, prefix='alsvc_', labels=labels,
                                                    namespace=NAMESPACE, priority='al-service-priority',
-                                                   log_level=self.config.core.logging.log_level)
+                                                   log_level=self.config.logging.log_level)
             # If we know where to find it, mount the classification into the service containers
             if CLASSIFICATION_CONFIGMAP:
                 self.controller.config_mount('classification-config', config_map=CLASSIFICATION_CONFIGMAP,
@@ -230,7 +230,7 @@ class ScalerServer(CoreBase):
             self.controller = DockerController(logger=self.log, prefix=NAMESPACE,
                                                cpu_overallocation=self.config.core.scaler.cpu_overallocation,
                                                memory_overallocation=self.config.core.scaler.memory_overallocation,
-                                               labels=labels, log_level=self.config.core.logging.log_level)
+                                               labels=labels, log_level=self.config.logging.log_level)
             # If we know where to find it, mount the classification into the service containers
             if CLASSIFICATION_HOST_PATH:
                 self.controller.global_mounts.append((CLASSIFICATION_HOST_PATH, '/etc/assemblyline/classification.yml'))

--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -218,7 +218,8 @@ class ScalerServer(CoreBase):
         if KUBERNETES_AL_CONFIG:
             self.log.info(f"Loading Kubernetes cluster interface on namespace: {NAMESPACE}")
             self.controller = KubernetesController(logger=self.log, prefix='alsvc_', labels=labels,
-                                                   namespace=NAMESPACE, priority='al-service-priority')
+                                                   namespace=NAMESPACE, priority='al-service-priority',
+                                                   log_level=self.config.core.logging.log_level)
             # If we know where to find it, mount the classification into the service containers
             if CLASSIFICATION_CONFIGMAP:
                 self.controller.config_mount('classification-config', config_map=CLASSIFICATION_CONFIGMAP,
@@ -229,7 +230,7 @@ class ScalerServer(CoreBase):
             self.controller = DockerController(logger=self.log, prefix=NAMESPACE,
                                                cpu_overallocation=self.config.core.scaler.cpu_overallocation,
                                                memory_overallocation=self.config.core.scaler.memory_overallocation,
-                                               labels=labels)
+                                               labels=labels, log_level=self.config.core.logging.log_level)
             # If we know where to find it, mount the classification into the service containers
             if CLASSIFICATION_HOST_PATH:
                 self.controller.global_mounts.append((CLASSIFICATION_HOST_PATH, '/etc/assemblyline/classification.yml'))

--- a/assemblyline_core/updater/run_updater.py
+++ b/assemblyline_core/updater/run_updater.py
@@ -328,7 +328,6 @@ class KubernetesUpdateInterface:
         environment_variables.extend([V1EnvVar(name=k, value=v) for k, v in env.items()])
         environment_variables.append(V1EnvVar(name="LOG_LEVEL", value=self.log_level))
 
-
         cores = docker_config.cpu_cores
         memory = docker_config.ram_mb
         memory_min = min(docker_config.ram_mb_min, memory)

--- a/assemblyline_core/updater/run_updater.py
+++ b/assemblyline_core/updater/run_updater.py
@@ -437,9 +437,9 @@ class ServiceUpdater(CoreBase):
             self.controller = KubernetesUpdateInterface(prefix='alsvc_', namespace=NAMESPACE,
                                                         priority_class='al-core-priority',
                                                         extra_labels=extra_labels,
-                                                        log_level=self.config.core.logging.log_level)
+                                                        log_level=self.config.logging.log_level)
         else:
-            self.controller = DockerUpdateInterface(log_level=self.config.core.logging.log_level)
+            self.controller = DockerUpdateInterface(log_level=self.config.logging.log_level)
 
     def sync_services(self):
         """Download the service list and make sure our settings are up to date"""


### PR DESCRIPTION
Scaler will pass on the logging level set in config.core.logging.log_level as an environment variable for services to read to set for their logger.

Related PR: https://github.com/CybercentreCanada/assemblyline-v4-service/pull/19