### PR TITLE
Dispatcher refactor dev

### DIFF
--- a/assemblyline_core/dispatching/client.py
+++ b/assemblyline_core/dispatching/client.py
@@ -91,7 +91,7 @@ class DispatchClient:
         """
         dispatcher_id = self.submission_assignments.get(sid)
         if dispatcher_id:
-            queue_name = reply_queue_name(prefix="D", suffix="WQ")
+            queue_name = reply_queue_name(prefix="D", suffix="ResponseQueue")
             queue = NamedQueue(queue_name, host=self.redis, ttl=30)
             command_queue = NamedQueue(DISPATCH_COMMAND_QUEUE+dispatcher_id)
             command_queue.push(DispatcherCommandMessage({

--- a/assemblyline_core/metrics/heartbeat_formatter.py
+++ b/assemblyline_core/metrics/heartbeat_formatter.py
@@ -119,7 +119,6 @@ class HeartbeatFormatter(object):
                         "metrics": m_data,
                         "queues": {
                             "ingest": self.dispatcher_submission_queue.length(),
-                            "files": 0
                         },
                         "component": m_name,
                     }


### PR DESCRIPTION
This changes: 
 - per dispatcher submission limits to be a dynamic fraction of the max in flight
 - heartbeat to include details on all dispatcher instances

If we want to try and tell if large jobs cause problematic imbalances between dispatchers, those numbers should give us a clue.