### PR TITLE
DEV: rename scaler_status to avoid templating conflict with scaler

### DIFF
--- a/assemblyline_core/metrics/heartbeat_formatter.py
+++ b/assemblyline_core/metrics/heartbeat_formatter.py
@@ -232,7 +232,7 @@ class HeartbeatFormatter(object):
             except Exception:
                 self.log.exception("An exception occurred while generating WatcherMessage")
 
-        elif m_type == "scaler-status":
+        elif m_type == "scaler_status":
             try:
                 msg = {
                     "sender": self.sender,

--- a/assemblyline_core/metrics/metrics_server.py
+++ b/assemblyline_core/metrics/metrics_server.py
@@ -18,7 +18,7 @@ from assemblyline.common import forge
 from assemblyline.remote.datatypes.queues.comms import CommsQueue
 
 METRICS_QUEUE = "assemblyline_metrics"
-NON_AGGREGATED = ['scaler', 'scaler-status']
+NON_AGGREGATED = ['scaler', 'scaler_status']
 
 
 def cleanup_metrics(input_dict):

--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -638,7 +638,7 @@ class ScalerServer(CoreBase):
 
             for service_name, metrics in service_metrics.items():
                 export_metrics_once(service_name, Status, metrics, host=HOSTNAME,
-                                    counter_type='scaler-status', config=self.config, redis=self.redis)
+                                    counter_type='scaler_status', config=self.config, redis=self.redis)
 
             memory, memory_total = self.controller.memory_info()
             cpu, cpu_total = self.controller.cpu_info()


### PR DESCRIPTION
scaler-status is falling into the scaler-* pattern which applies the wrong templating to that index, consequently the wrong rollover alias.

Substituting hyphen for underscore will cause AL to create a new template and fix the issue on deployment. 
Bug is seen in all our prod instances and causing ILM errors.