### PR TITLE
DEV2: Feature/metric component datastreams

### DIFF
--- a/assemblyline_core/metrics/helper.py
+++ b/assemblyline_core/metrics/helper.py
@@ -69,7 +69,7 @@ def create_ilm_policy(es, name, ilm_config):
 def ensure_indexes(log, es, config, indexes, datastream_enabled=False):
     for index_type in indexes:
         try:
-            index = f"al_metrics_{index_type}"
+            index = f"al_metrics_{index_type}_ds" if datastream_enabled else f"al_metrics_{index_type}"
             policy = f"{index}_policy"
             while True:
                 try:
@@ -107,7 +107,7 @@ def ensure_indexes(log, es, config, indexes, datastream_enabled=False):
                     if datastream_enabled:
                         template_body['index_patterns'] = f"{index}*"
                         template_body['data_stream'] = {}
-                        template_body['priority'] = 1
+                        template_body['priority'] = 10
 
                 # Legacy template
                 else:

--- a/assemblyline_core/metrics/metrics_server.py
+++ b/assemblyline_core/metrics/metrics_server.py
@@ -218,14 +218,22 @@ class MetricsServer(ServerBase):
                 else:
                     output_metrics[key] = value
 
-            timestamp_field = "@timestamp" if self.is_datastream else "timestamp"
+            ensure_indexes(self.log, self.es, self.config.core.metrics.elasticsearch, [component_type],
+                           datastream_enabled=self.is_datastream)
+
+            timestamp_field = "timestamp"
+            index = f"al_metrics_{component_type}"
+            # Were data streams created for the index specified?
+            try:
+                if self.es.indices.get_data_stream(name=index):
+                    timestamp_field = "@timestamp"
+            except elasticsearch.exceptions.TransportError:
+                pass
             output_metrics[timestamp_field] = timestamp
             output_metrics = cleanup_metrics(output_metrics)
 
             self.log.info(output_metrics)
-            ensure_indexes(self.log, self.es, self.config.core.metrics.elasticsearch, [component_type],
-                           datastream_enabled=self.is_datastream)
-            with_retries(self.log, self.es.index, index=f"al_metrics_{component_type}", body=output_metrics)
+            with_retries(self.log, self.es.index, index=index, body=output_metrics)
 
         self.log.info("Metrics aggregated. Waiting for next run...")
 

--- a/assemblyline_core/metrics/metrics_server.py
+++ b/assemblyline_core/metrics/metrics_server.py
@@ -221,15 +221,15 @@ class MetricsServer(ServerBase):
             ensure_indexes(self.log, self.es, self.config.core.metrics.elasticsearch, [component_type],
                            datastream_enabled=self.is_datastream)
 
-            timestamp_field = "timestamp"
             index = f"al_metrics_{component_type}"
             # Were data streams created for the index specified?
             try:
-                if self.es.indices.get_data_stream(name=index):
-                    timestamp_field = "@timestamp"
+                if self.es.indices.get_index_template(name=f"{index}_ds"):
+                    output_metrics['@timestamp'] = timestamp
+                    index = f"{index}_ds"
             except elasticsearch.exceptions.TransportError:
                 pass
-            output_metrics[timestamp_field] = timestamp
+            output_metrics['timestamp'] = timestamp
             output_metrics = cleanup_metrics(output_metrics)
 
             self.log.info(output_metrics)


### PR DESCRIPTION
This PR is only meant to check for anomalies in staging deployment. None are expected.

The changes here should only apply to prod systems to allow the ability to migrate data from indexes to new datastreams while maintaining current use under the old index pattern. Original timestamp field will be retained in datastreams to maintain this functionality.