### PR TITLE
Hotfix/cond update mount

### DIFF
--- a/assemblyline_core/scaler/controllers/docker_ctl.py
+++ b/assemblyline_core/scaler/controllers/docker_ctl.py
@@ -321,7 +321,7 @@ class DockerController(ControllerInterface):
             out.append(container.name)
         return out
 
-    def start_stateful_container(self, service_name, container_name, spec, labels):
+    def start_stateful_container(self, service_name, container_name, spec, labels, mount_updates=False):
         volumes = {_n: {'bind': _v.mount_path, 'mode': 'rw'} for _n, _v in spec.volumes.items()}
         deployment_name = f'{service_name}-dep-{container_name}'
 

--- a/assemblyline_core/scaler/controllers/kubernetes_ctl.py
+++ b/assemblyline_core/scaler/controllers/kubernetes_ctl.py
@@ -361,7 +361,7 @@ class KubernetesController(ControllerInterface):
             self.api.delete_namespaced_secret(pull_secret_name, self.namespace, _request_timeout=API_TIMEOUT)
 
         # If an updater container then mount update-directory otherwise ignore
-        mount_updates = any(docker_config.command)
+        mount_updates = bool(docker_config.command)
 
         all_labels = dict(self._labels)
         all_labels['component'] = service_name

--- a/assemblyline_core/scaler/controllers/kubernetes_ctl.py
+++ b/assemblyline_core/scaler/controllers/kubernetes_ctl.py
@@ -164,7 +164,7 @@ class KubernetesController(ControllerInterface):
     def add_profile(self, profile):
         """Tell the controller about a service profile it needs to manage."""
         self._create_deployment(profile.name, self._deployment_name(profile.name),
-                                profile.container_config, profile.shutdown_seconds, 0)
+                                profile.container_config, profile.shutdown_seconds, 0, profile.mount_updates)
 
     def _monitor_system_info(self):
         while True:
@@ -310,7 +310,7 @@ class KubernetesController(ControllerInterface):
         )]
 
     def _create_deployment(self, service_name: str, deployment_name: str, docker_config,
-                           shutdown_seconds, scale: int, labels=None, volumes=None, mounts=None, mount_updates=False):
+                           shutdown_seconds, scale: int, labels=None, volumes=None, mounts=None, mount_updates=True):
 
         replace = False
 
@@ -453,7 +453,7 @@ class KubernetesController(ControllerInterface):
 
     def restart(self, service):
         self._create_deployment(service.name, self._deployment_name(service.name), service.container_config,
-                                service.shutdown_seconds, self.get_target(service.name))
+                                service.shutdown_seconds, self.get_target(service.name), service.mount_updates)
 
     def get_running_container_names(self):
         pods = self.api.list_pod_for_all_namespaces(field_selector='status.phase==Running',

--- a/assemblyline_core/scaler/controllers/kubernetes_ctl.py
+++ b/assemblyline_core/scaler/controllers/kubernetes_ctl.py
@@ -164,7 +164,7 @@ class KubernetesController(ControllerInterface):
     def add_profile(self, profile):
         """Tell the controller about a service profile it needs to manage."""
         self._create_deployment(profile.name, self._deployment_name(profile.name),
-                                profile.container_config, profile.shutdown_seconds, 0, profile.mount_updates)
+                                profile.container_config, profile.shutdown_seconds, 0, mount_updates=profile.mount_updates)
 
     def _monitor_system_info(self):
         while True:

--- a/assemblyline_core/scaler/controllers/kubernetes_ctl.py
+++ b/assemblyline_core/scaler/controllers/kubernetes_ctl.py
@@ -453,7 +453,8 @@ class KubernetesController(ControllerInterface):
 
     def restart(self, service):
         self._create_deployment(service.name, self._deployment_name(service.name), service.container_config,
-                                service.shutdown_seconds, self.get_target(service.name), service.mount_updates)
+                                service.shutdown_seconds, self.get_target(service.name),
+                                mount_updates=service.mount_updates)
 
     def get_running_container_names(self):
         pods = self.api.list_pod_for_all_namespaces(field_selector='status.phase==Running',

--- a/assemblyline_core/scaler/controllers/kubernetes_ctl.py
+++ b/assemblyline_core/scaler/controllers/kubernetes_ctl.py
@@ -262,26 +262,27 @@ class KubernetesController(ControllerInterface):
     def _create_metadata(deployment_name: str, labels: Dict[str, str]):
         return V1ObjectMeta(name=deployment_name, labels=labels)
 
-    def _create_volumes(self, service_name):
+    def _create_volumes(self, service_name, mount_updates=False):
         volumes, mounts = [], []
 
         # Attach the mount that provides the config file
         volumes.extend(self.config_volumes.values())
         mounts.extend(self.config_mounts.values())
 
-        # Attach the mount that provides the update
-        volumes.append(V1Volume(
-            name='update-directory',
-            persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
-                claim_name=FILE_UPDATE_VOLUME
-            ),
-        ))
+        if mount_updates:
+            # Attach the mount that provides the update
+            volumes.append(V1Volume(
+                name='update-directory',
+                persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
+                    claim_name=FILE_UPDATE_VOLUME
+                ),
+            ))
 
-        mounts.append(V1VolumeMount(
-            name='update-directory',
-            mount_path=CONTAINER_UPDATE_DIRECTORY,
-            sub_path=service_name
-        ))
+            mounts.append(V1VolumeMount(
+                name='update-directory',
+                mount_path=CONTAINER_UPDATE_DIRECTORY,
+                sub_path=service_name
+            ))
 
         return volumes, mounts
 
@@ -359,11 +360,14 @@ class KubernetesController(ControllerInterface):
         elif current_pull_secret:
             self.api.delete_namespaced_secret(pull_secret_name, self.namespace, _request_timeout=API_TIMEOUT)
 
+        # If an updater container then mount update-directory otherwise ignore
+        mount_updates = any(docker_config.command)
+
         all_labels = dict(self._labels)
         all_labels['component'] = service_name
         all_labels.update(labels or {})
 
-        all_volumes, all_mounts = self._create_volumes(service_name)
+        all_volumes, all_mounts = self._create_volumes(service_name, mount_updates)
         all_volumes.extend(volumes or [])
         all_mounts.extend(mounts or [])
         metadata = self._create_metadata(deployment_name=deployment_name, labels=all_labels)

--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -397,16 +397,16 @@ class ScalerServer(CoreBase):
                             # Update RAM, CPU, licence requirements for running services
                             else:
                                 profile = self.profiles[name]
-
                                 if service.licence_count == 0:
                                     profile._max_instances = float('inf')
                                 else:
                                     profile._max_instances = service.licence_count
 
-                                if profile.container_config != docker_config or profile.config_hash != config_hash:
+                                if profile.container_config != docker_config or profile.config_hash != config_hash or profile.mount_updates != mount_updates:
                                     self.log.info(f"Updating deployment information for {name}")
                                     profile.container_config = docker_config
                                     profile.config_hash = config_hash
+                                    profile.mount_updates = mount_updates
                                     self.controller.restart(profile)
                                     self.log.info(f"Deployment information for {name} replaced")
 

--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -85,7 +85,8 @@ class ServiceProfile:
     This includes how the service should be run, and conditions related to the scaling of the service.
     """
     def __init__(self, name, container_config: DockerConfig, config_hash=0, min_instances=0, max_instances=None,
-                 growth: float = 600, shrink: Optional[float] = None, backlog=500, queue=None, shutdown_seconds=30):
+                 growth: float = 600, shrink: Optional[float] = None, backlog=500, queue=None, shutdown_seconds=30,
+                 mount_updates=True):
         """
         :param name: Name of the service to manage
         :param container_config: Instructions on how to start this service
@@ -102,6 +103,7 @@ class ServiceProfile:
         self.target_duty_cycle = 0.9
         self.shutdown_seconds = shutdown_seconds
         self.config_hash = config_hash
+        self.mount_updates = mount_updates
 
         # How many instances we want, and can have
         self.min_instances = self._min_instances = max(0, int(min_instances))
@@ -187,6 +189,7 @@ class ServiceProfile:
             shrink=self.shrink_threshold,
             backlog=self.backlog,
             shutdown_seconds=self.shutdown_seconds,
+            mount_updates=self.mount_updates
         )
         prof.desired_instances = self.desired_instances
         prof.running_instances = self.running_instances
@@ -388,6 +391,7 @@ class ScalerServer(CoreBase):
                                     queue=get_service_queue(name, self.redis),
                                     # Give service an extra 30 seconds to upload results
                                     shutdown_seconds=service.timeout + 30,
+                                    mount_updates=mount_updates
                                 ))
 
                             # Update RAM, CPU, licence requirements for running services

--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -402,11 +402,10 @@ class ScalerServer(CoreBase):
                                 else:
                                     profile._max_instances = service.licence_count
 
-                                if profile.container_config != docker_config or profile.config_hash != config_hash or profile.mount_updates != mount_updates:
+                                if profile.container_config != docker_config or profile.config_hash != config_hash:
                                     self.log.info(f"Updating deployment information for {name}")
                                     profile.container_config = docker_config
                                     profile.config_hash = config_hash
-                                    profile.mount_updates = mount_updates
                                     self.controller.restart(profile)
                                     self.log.info(f"Deployment information for {name} replaced")
 

--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -330,6 +330,7 @@ class ScalerServer(CoreBase):
                 name = service.name
                 stage = self.get_service_stage(service.name)
                 discovered_services.append(name)
+                mount_updates = bool(service.update_config)
 
                 # noinspection PyBroadException
                 try:
@@ -341,7 +342,8 @@ class ScalerServer(CoreBase):
                                 service_name=service.name,
                                 container_name=_n,
                                 spec=dependency,
-                                labels={'dependency_for': service.name}
+                                labels={'dependency_for': service.name},
+                                mount_updates=mount_updates
                             )
 
                         # Move to the next service stage


### PR DESCRIPTION
Service deployments will only mount the update-directory if they have to (containing update_config). Otherwise, they will not mount it.

Current fix deployed in staging under dev91.

Example:
```
# kubectl get deployment alsvc-yara
...
        volumeMounts:
        - mountPath: /etc/assemblyline/classification.yml
          name: classification-config
          subPath: classification
        - mountPath: /mount/updates/
          name: update-directory
          subPath: YARA
...
```

```
# kubectl get deployment alsvc-swiffer
...
        volumeMounts:
        - mountPath: /etc/assemblyline/classification.yml
          name: classification-config
          subPath: classification
...
```