### PR TITLE
Display failure metrics due to max_retry to be consistent with Error Viewer

### DIFF
--- a/assemblyline_core/dispatching/dispatcher.py
+++ b/assemblyline_core/dispatching/dispatcher.py
@@ -48,6 +48,7 @@ class ResultSummary:
 
 class SubmissionTask:
     """Dispatcher internal model for submissions"""
+
     def __init__(self, submission, completed_queue):
         self.submission: Submission = Submission(submission)
         self.completed_queue = str(completed_queue)
@@ -319,13 +320,14 @@ class Dispatcher(ThreadedCoreBase):
         task.file_names[submission.files[0].sha256] = submission.files[0].name or submission.files[0].sha256
         self.dispatch_file(task, submission.files[0].sha256)
 
-    def dispatch_file(self, task: SubmissionTask, sha256: str) -> bool:
+    def dispatch_file(self, task: SubmissionTask, sha256: str, timed_out_host: str = None) -> bool:
         """
         Dispatch to any outstanding services for the given file.
         If nothing can be dispatched, check if the submission is finished.
 
         :param task: Submission task object.
         :param sha256: hash of the file to check.
+        :param timed_out_host: Name of the host that timed out after maximum service attempts.
         :return: true if submission is finished.
         """
         submission = task.submission
@@ -431,7 +433,7 @@ class Dispatcher(ThreadedCoreBase):
                 # Check if we have attempted this too many times already.
                 task.service_attempts[key] += 1
                 if task.service_attempts[key] > 3:
-                    self.retry_error(task, sha256, service_name)
+                    self.retry_error(task, sha256, service_name, timed_out_host)
                     continue
 
                 # Its a new task, send it to the service
@@ -694,7 +696,7 @@ class Dispatcher(ThreadedCoreBase):
             'sender': 'dispatcher',
         }).as_primitives())
 
-    def retry_error(self, task: SubmissionTask, sha256, service_name):
+    def retry_error(self, task: SubmissionTask, sha256, service_name, host):
         self.log.warning(f"[{task.submission.sid}/{sha256}] "
                          f"{service_name} marking task failed: TASK PREEMPTED ")
 
@@ -704,7 +706,7 @@ class Dispatcher(ThreadedCoreBase):
             created='NOW',
             expiry_ts=now_as_iso(ttl * 24 * 60 * 60) if ttl else None,
             response=dict(
-                message=f'The number of retries has passed the limit.',
+                message='The number of retries has passed the limit.',
                 service_name=service_name,
                 service_version='0',
                 status='FAIL_NONRECOVERABLE',
@@ -720,7 +722,8 @@ class Dispatcher(ThreadedCoreBase):
         task.running_services.pop((sha256, service_name), None)
         task.service_errors[(sha256, service_name)] = error_key
 
-        export_metrics_once(service_name, ServiceMetrics, dict(fail_nonrecoverable=1), counter_type='service')
+        export_metrics_once(service_name, ServiceMetrics, dict(fail_nonrecoverable=1),
+                            counter_type='service', host=host)
 
         # Send the result key to any watching systems
         msg = {'status': 'FAIL', 'cache_key': error_key}
@@ -1028,7 +1031,7 @@ class Dispatcher(ThreadedCoreBase):
                       f"timed out on {service_task.fileinfo.sha256}.")
 
         _, worker_id = task.running_services.pop((sha256, service_name))
-        self.dispatch_file(task, sha256)
+        self.dispatch_file(task, sha256, timed_out_host=worker_id)
 
         # We push the task of killing the container off on the scaler, which already has root access
         # the scaler can also double check that the service name and container id match, to be sure


### PR DESCRIPTION
Relating to: https://cccs.atlassian.net/browse/AL-1190

Services that timeout after hitting max retry for unknown reasons (service dependent) are not displayed in the Dashboard. However, messages in the Error Viewer indicate there was a non_recoverable failure due to hitting max retry.

By passing on the host (or any host value), we'll be able to display failures due to max retries.