### PR TITLE
Use static host 'dispatcher' on retry_error

### DIFF
--- a/assemblyline_core/dispatching/dispatcher.py
+++ b/assemblyline_core/dispatching/dispatcher.py
@@ -320,7 +320,7 @@ class Dispatcher(ThreadedCoreBase):
         task.file_names[submission.files[0].sha256] = submission.files[0].name or submission.files[0].sha256
         self.dispatch_file(task, submission.files[0].sha256)
 
-    def dispatch_file(self, task: SubmissionTask, sha256: str, timed_out_host: str = None) -> bool:
+    def dispatch_file(self, task: SubmissionTask, sha256: str) -> bool:
         """
         Dispatch to any outstanding services for the given file.
         If nothing can be dispatched, check if the submission is finished.
@@ -433,7 +433,7 @@ class Dispatcher(ThreadedCoreBase):
                 # Check if we have attempted this too many times already.
                 task.service_attempts[key] += 1
                 if task.service_attempts[key] > 3:
-                    self.retry_error(task, sha256, service_name, timed_out_host)
+                    self.retry_error(task, sha256, service_name)
                     continue
 
                 # Its a new task, send it to the service
@@ -451,7 +451,7 @@ class Dispatcher(ThreadedCoreBase):
                 # If we are not waiting, and have not taken an action, we must have hit the
                 # retry limit on the only service running. In that case, we can move directly
                 # onto the next stage of services, so recurse to trigger them.
-                return self.dispatch_file(task, sha256, timed_out_host)
+                return self.dispatch_file(task, sha256)
 
         else:
             self.counter.increment('files_completed')
@@ -696,7 +696,7 @@ class Dispatcher(ThreadedCoreBase):
             'sender': 'dispatcher',
         }).as_primitives())
 
-    def retry_error(self, task: SubmissionTask, sha256, service_name, host):
+    def retry_error(self, task: SubmissionTask, sha256, service_name):
         self.log.warning(f"[{task.submission.sid}/{sha256}] "
                          f"{service_name} marking task failed: TASK PREEMPTED ")
 
@@ -723,7 +723,7 @@ class Dispatcher(ThreadedCoreBase):
         task.service_errors[(sha256, service_name)] = error_key
 
         export_metrics_once(service_name, ServiceMetrics, dict(fail_nonrecoverable=1),
-                            counter_type='service', host=host)
+                            counter_type='service', host='dispatcher')
 
         # Send the result key to any watching systems
         msg = {'status': 'FAIL', 'cache_key': error_key}
@@ -1031,7 +1031,7 @@ class Dispatcher(ThreadedCoreBase):
                       f"timed out on {service_task.fileinfo.sha256}.")
 
         _, worker_id = task.running_services.pop((sha256, service_name))
-        self.dispatch_file(task, sha256, timed_out_host=worker_id)
+        self.dispatch_file(task, sha256)
 
         # We push the task of killing the container off on the scaler, which already has root access
         # the scaler can also double check that the service name and container id match, to be sure

--- a/assemblyline_core/dispatching/dispatcher.py
+++ b/assemblyline_core/dispatching/dispatcher.py
@@ -451,7 +451,7 @@ class Dispatcher(ThreadedCoreBase):
                 # If we are not waiting, and have not taken an action, we must have hit the
                 # retry limit on the only service running. In that case, we can move directly
                 # onto the next stage of services, so recurse to trigger them.
-                return self.dispatch_file(task, sha256)
+                return self.dispatch_file(task, sha256, timed_out_host)
 
         else:
             self.counter.increment('files_completed')


### PR DESCRIPTION
Just use a static host 'dispatcher' on retry_error. 
Differentiate between a hard failure from a host vs retried timeout across many hosts.