### PR TITLE
Corrects an issue where updater would not pass service apikeys during service registration

### DIFF
--- a/assemblyline_core/updater/run_updater.py
+++ b/assemblyline_core/updater/run_updater.py
@@ -565,6 +565,7 @@ class ServiceUpdater(CoreBase):
                     env={
                         "SERVICE_TAG": update_data['latest_tag'],
                         "SERVICE_API_HOST": os.environ.get('SERVICE_API_HOST', "http://al_service_server:5003"),
+                        "SERVICE_API_KEY": os.environ.get('SERVICE_API_KEY','ThisIsARandomAuthKey...ChangeMe!'),
                         "REGISTER_ONLY": 'true'
                     },
                     network='al_registration',


### PR DESCRIPTION
Corrects an issue where service apikeys were not being passed from the updater service to the service server during service registration. This resulted in the update failing unless the default apikey was used.