### PR TITLE
Hotfix/update expired alerts

### DIFF
--- a/test/test_alerter.py
+++ b/test/test_alerter.py
@@ -15,7 +15,7 @@ from assemblyline.odm.randomizer import random_model_obj, get_random_tags
 from assemblyline.remote.datatypes import get_client
 from assemblyline.remote.datatypes.queues.named import NamedQueue
 
-NUM_SUBMISSIONS = 2
+NUM_SUBMISSIONS = 3
 all_submissions = []
 
 


### PR DESCRIPTION
Relating to: https://cccs.atlassian.net/browse/AL-1288

Apparent cause is that the alert no longer exists in the alert collection (likely due to being expired or removed from the index alias).
If this should happen, we should create the alert as if it were new.