### PR TITLE
Bugfix for main thread exit

### DIFF
--- a/assemblyline_core/server_base.py
+++ b/assemblyline_core/server_base.py
@@ -93,6 +93,7 @@ class ServerBase(threading.Thread):
         except Exception:
             _, self._exception, self._traceback = sys.exc_info()
             self.log.exception("Exiting:")
+            self.stop()
 
     def serve_forever(self):
         self.start()


### PR DESCRIPTION
When the main function enters an uncontrolled crash stop function should be called.