### PR TITLE
allow privileged into core network

### DIFF
--- a/assemblyline_core/scaler/controllers/docker_ctl.py
+++ b/assemblyline_core/scaler/controllers/docker_ctl.py
@@ -185,6 +185,9 @@ class DockerController(ControllerInterface):
             detach=True,
         )
 
+        if prof.privileged:
+            self.core_network.connect(container, aliases=[container_name])
+
         if cfg.allow_internet_access:
             self.external_network.connect(container)
 


### PR DESCRIPTION
In our dev setup, we don't use a 'core network'; didn't catch this earlier.