### PR TITLE
Update docker_ctl.py

### DIFF
--- a/assemblyline_core/scaler/controllers/docker_ctl.py
+++ b/assemblyline_core/scaler/controllers/docker_ctl.py
@@ -207,7 +207,7 @@ class DockerController(ControllerInterface):
         if prof.privileged:
             self._connect_to_network(container, self.core_network)
 
-        if cfg.allow_internet_access:
+        if cfg.allow_internet_access or prof.is_external:
             self._connect_to_network(container, self.external_network)
 
     def _start_container(


### PR DESCRIPTION
Allow a docker container to connect to the external network if the `is_external` field is set to True in addition to the `docker_config.allow_internet_access` field