### PR TITLE
Ensure all tags are returned from _get_dockerhub_tags

### DIFF
--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -1,3 +1,4 @@
+# noinspection PyInterpreter
 import json
 import requests
 import re
@@ -188,16 +189,19 @@ def get_latest_tag_for_service(
 # Default for obtaining tags from DockerHub
 def _get_dockerhub_tags(image_name, update_channel, proxies=None):
     # Find latest tag for each types
+    rv = []
     url = f"https://{DEFAULT_DOCKER_REGISTRY}/v2/repositories/{image_name}/tags" \
-        f"?page_size=5&page=1&name={update_channel}"
+          f"?page_size=50&page=1&name={update_channel}"
+    while True:
+        resp = requests.get(url, proxies=proxies)
+        if resp.ok:
+            resp_data = resp.json()
+            rv.extend([x['name'] for x in resp_data['results']])
+            # Page until there are no results left
+            url = resp_data.get('next', None)
+            if url is None:
+                break
+        else:
+            break
 
-    # Get tag list
-    resp = requests.get(url, proxies=proxies)
-
-    # Test for valid response
-    if resp.ok:
-        # Test for positive list of tags
-        resp_data = resp.json()
-        return [x['name'] for x in resp_data['results']]
-
-    return []
+    return rv

--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -1,4 +1,3 @@
-# noinspection PyInterpreter
 import json
 import requests
 import re


### PR DESCRIPTION
At present, only the five most recent tags for a given image are returned when querying Dockerhub in the updater.  This means that the updater is unable to find tags for service images for previous versions of Assemblyline.

(As an example, when attempting to deploy a new 4.4.0 Assemblyline, the existing code fails to find matching tags for at least `elfparser` and `batchdeobufscator`, since the 5 tags returned were `stable` and various `4.5.0.*` permutations.  Corollary to this -- it is presently not possible to enable new services on a 4.4 or earlier deployment of Assemblyline.)

The code in this PR retrieves all tags for a given image - across page boundaries if neccessary - and returns them to the caller for filtering.