### PR TITLE
Handle dependencies not existing before

### DIFF
--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -623,7 +623,7 @@ class ScalerServer(ThreadedCoreBase):
                         profile.privileged = service.privileged
 
                         for dependency_name, dependency_blob in dependency_blobs.items():
-                            if profile.dependency_blobs[dependency_name] != dependency_blob:
+                            if profile.dependency_blobs.get(dependency_name, '') != dependency_blob:
                                 self.log.info(f"Updating deployment information for {name}/{dependency_name}")
                                 profile.dependency_blobs[dependency_name] = dependency_blob
                                 self.controller.start_stateful_container(


### PR DESCRIPTION
If a dependency didn't exist before, there is no existing dependency blob key.

For example, introducing a new dependency to the existing service, results in
the following error on updating:

```
Error applying service settings from: Network-Information\nTraceback (most recent call last):
  File \"/var/lib/assemblyline/.local/lib/python3.11/site-packages/assemblyline_core/scaler/scaler_server.py\", line 626, in _sync_service
    if profile.dependency_blobs[dependency_name] != dependency_blob:
       ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^\nKeyError: 'netinfo_cache'
```

A similar error appears if you try to rename a dependency