### PR TITLE
Handle dependencies not existing before (dev)

### DIFF
--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -623,7 +623,7 @@ class ScalerServer(ThreadedCoreBase):
                         profile.privileged = service.privileged
 
                         for dependency_name, dependency_blob in dependency_blobs.items():
-                            if profile.dependency_blobs[dependency_name] != dependency_blob:
+                            if profile.dependency_blobs.get(dependency_name, '') != dependency_blob:
                                 self.log.info(f"Updating deployment information for {name}/{dependency_name}")
                                 profile.dependency_blobs[dependency_name] = dependency_blob
                                 self.controller.start_stateful_container(


### PR DESCRIPTION
If a dependency didn't exist before, there is no existing dependency blob key.