### PR TITLE
Prioritize authentication to container registries from system configuration

### DIFF
--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -35,6 +35,7 @@ from assemblyline.common.uid import get_id_from_data
 from assemblyline.common.forge import get_classification, get_service_queue, get_apm_client
 from assemblyline.common.constants import SCALER_TIMEOUT_QUEUE, SERVICE_STATE_HASH, ServiceStatus
 from assemblyline.common.version import FRAMEWORK_VERSION, SYSTEM_VERSION
+from assemblyline_core.updater.helper import get_registry_config
 from assemblyline_core.scaler.controllers import KubernetesController
 from assemblyline_core.scaler.controllers.interface import ServiceControlError
 from assemblyline_core.server_base import ServiceStage, ThreadedCoreBase
@@ -514,6 +515,12 @@ class ScalerServer(ThreadedCoreBase):
             for var in default_settings.environment:
                 if var.name not in set_keys:
                     docker_config.environment.append(var)
+
+            # Set authentication to registry to pull the image
+            auth_config = get_registry_config(docker_config, self.config)
+            docker_config.registry_username = auth_config['username']
+            docker_config.registry_password = auth_config['password']
+
             return docker_config
 
         # noinspection PyBroadException
@@ -533,7 +540,7 @@ class ScalerServer(ThreadedCoreBase):
             if not service.version.startswith(system_spec):
                 # If FW and SYS version don't prefix in the service version, we can't guarantee the
                 # service is compatible. Disable and treat it as incompatible due to service version.
-                self.log.warning("Disabling service with incompatible version. "
+                self.log.warning(f"Disabling {service.name} with incompatible version. "
                                  f"[{service.version} != '{system_spec}.X.{service.update_channel}Y'].")
                 disable_incompatible_service()
             elif service.update_config and service.update_config.wait_for_update and not service.update_config.sources:

--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -133,7 +133,13 @@ REGISTRY_TYPE_MAPPING = {
 }
 
 def get_registry_config(docker_config: DockerConfig, system_config: SystemConfig) -> Dict[str, str]:
-    server = docker_config.image.split("/", 1)[0]
+    # Fix service image for calling Docker API
+    image_variables = defaultdict(str)
+    image_variables.update(system_config.services.image_variables)
+    image_variables.update(system_config.services.update_image_variables)
+    searchable_image = string.Template(docker_config.image).safe_substitute(image_variables)
+
+    server = searchable_image.split("/", 1)[0]
 
     # Prioritize authentication given as a system configuration
     registries: List[ServiceRegistry] = system_config.services.registries or []

--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -13,6 +13,7 @@ from collections import defaultdict
 from logging import Logger
 from typing import Dict
 from packaging.version import parse, Version
+from urllib.parse import urlencode
 
 DEFAULT_DOCKER_REGISTRY = "hub.docker.com"
 
@@ -144,9 +145,22 @@ def get_registry_config(docker_config: DockerConfig, system_config: SystemConfig
     return dict(username=docker_config.registry_username, password=docker_config.registry_password,
                 type=docker_config.registry_type)
 
-
-def get_latest_tag_for_service(
-        service_config: ServiceConfig, system_config: SystemConfig, logger: Logger, prefix: str = ""):
+def get_latest_tag_for_service(service_config: ServiceConfig, system_config: SystemConfig, logger: Logger,
+                               prefix: str = ""):
+    """
+    Retrieves the latest compatible tag for a given service from its respective Docker registry.
+    This function processes the image name to determine the correct server, authenticates
+    with the registry, and then fetches the latest tag that matches the service's framework
+    and system version constraints. It handles different registry configurations including
+    private and public ones.
+    Args:
+        service_config (ServiceConfig): The configuration object for the service which includes Docker configuration.
+        system_config (SystemConfig): System-wide configuration which includes service updates and registry configurations.
+        logger (Logger): Logger object for logging messages.
+        prefix (str, optional): A prefix string to prepend to log messages for clarity in logs.
+    Returns:
+        tuple: Returns a tuple of the final image name, the latest tag, and authentication config used for the Docker registry.
+    """
     def process_image(image):
         # Find which server to search in
         server = image.split("/")[0]
@@ -166,10 +180,9 @@ def get_latest_tag_for_service(
 
         # Split repo name without the tag
         image_name = image_name.rsplit(":", 1)[0]
-
         return server, image_name
 
-    # Extract info
+    # Extract and process service information
     service_name = service_config.name
     image = service_config.docker_config.image
     update_channel = service_config.update_channel
@@ -208,32 +221,27 @@ def get_latest_tag_for_service(
             break
 
     if server == DEFAULT_DOCKER_REGISTRY:
-        tags = _get_dockerhub_tags(image_name, update_channel, proxies)
+        tags = _get_dockerhub_tags(image_name, update_channel, proxies, logger=logger)
     else:
         tags = registry._get_proprietary_registry_tags(server, image_name, auth,
                                                        not system_config.services.allow_insecure_registry,
                                                        proxies, token_server)
-
-    tag_name = None
-
     # Pre-filter tags to only consider 'compatible' tags relative to the running system
-    tags = [t for t in tags
-            if re.match(f"({FRAMEWORK_VERSION})\.({SYSTEM_VERSION})\.\\d+\.({update_channel})\\d+", t)]
-
+    tags = [tag for tag in tags
+            if re.match(f"({FRAMEWORK_VERSION})\.({SYSTEM_VERSION})\.\\d+\.({update_channel})\\d+", tag)]
     if not tags:
-        logger.warning(f"{prefix}Cannot fetch latest tag for service {service_name} - {image_name}"
+        logger.warning(f"{prefix} Cannot fetch latest tag for service {service_name} - {image_name}" \
                        f" => [server: {server}, repo_name: {image_name}, channel: {update_channel}]")
-    else:
-        for t in tags:
-            t_version = Version(t.replace(update_channel, ""))
-            # Tag name gets assigned to the first viable option then relies on comparison to get the latest
-            if not tag_name:
-                tag_name = t
-            elif t_version.major == FRAMEWORK_VERSION and t_version.minor == SYSTEM_VERSION and \
-                    t_version > parse(tag_name.replace(update_channel, "")):
-                tag_name = t
-
-        logger.info(f"{prefix}Latest {service_name} tag on {update_channel.upper()} channel is: {tag_name}")
+    tag_name = None
+    for tag in tags:
+        t_version = Version(tag.replace(update_channel, ""))
+        # Tag name gets assigned to the first viable option then relies on comparison to get the latest
+        if not tag_name:
+            tag_name = tag
+        elif t_version.major == FRAMEWORK_VERSION and t_version.minor == SYSTEM_VERSION and \
+                t_version > parse(tag_name.replace(update_channel, "")):
+            tag_name = tag
+    logger.info(f"{prefix}Latest {service_name} tag on {update_channel.upper()} channel is: {tag_name}")
 
     # Fix service image for use in Kubernetes
     image_variables = defaultdict(str)
@@ -247,43 +255,73 @@ def get_latest_tag_for_service(
 
     return image_name, tag_name, auth_config
 
-
-# Default for obtaining tags from DockerHub
-def _get_dockerhub_tags(image_name, update_channel, proxies=None):
-    # Find latest tag for each types
-    rv = []
+def _get_dockerhub_tags(image_name, update_channel, proxies=None, docker_registry=DEFAULT_DOCKER_REGISTRY,
+                        logger: Logger=None):
+    """
+    Retrieve DockerHub tags for a specific image and update channel.
+    Args:
+    image_name (str): Full name of the image (including namespace).
+    update_channel (str): Specific channel to filter tags (e.g., stable, beta).
+    proxies (dict, optional): Proxy configuration.
+    docker_registry (str, optional): Docker registry URL. Defaults to DEFAULT_DOCKER_REGISTRY.
+    Returns:
+    list: A list of tag names that match the given criteria, or None if an error occurs.
+    """
     namespace, repository = image_name.split('/', 1)
-    url = f"https://{DEFAULT_DOCKER_REGISTRY}/v2/namespaces/{namespace}/repositories/{repository}/tags" \
-        f"?page_size=50&page=1&name={update_channel}&ordering=last_updated"
-
+    base_url = f"https://{docker_registry}/v2/namespaces/{namespace}/repositories/{repository}/tags"
+    query_params = {
+        'page_size': 50,
+        'page': 1,
+        'name': update_channel,
+        'ordering': 'last_updated'
+    }
+    url = f"{base_url}?{urlencode(query_params)}"
     while True:
-        resp = requests.get(url, proxies=proxies)
-        if resp.ok:
-            resp_data = resp.json()
+        try:
+            response = requests.get(url, proxies=proxies)
+            response.raise_for_status()  # Raises an HTTPError for bad responses
+            response_data = response.json()
+            tags = []
             if namespace == "cccs":
                 # The tags are coming from a repository managed by the Assemblyline team
-                for x in resp_data['results']:
-                    tag_name = x['name']
-                    if tag_name == f"{FRAMEWORK_VERSION}.{SYSTEM_VERSION}.{update_channel}":
+                for tag_info in response_data['results']:
+                    tag_name = tag_info.get('name')
+                    if tag_name and tag_name == f"{FRAMEWORK_VERSION}.{SYSTEM_VERSION}.{update_channel}":
                         # Ignore tag aliases containing the update_channel
                         continue
-
-                    if tag_name.startswith(f"{FRAMEWORK_VERSION}.{SYSTEM_VERSION}"):
+                    if tag_name and tag_name.startswith(f"{FRAMEWORK_VERSION}.{SYSTEM_VERSION}"):
                         # Because the order of paging is based on `last_updated`,
                         # we can return the first valid candidate
+                        logger.info(f"Valid tag found: {tag_name}")
                         return [tag_name]
             else:
                 # The tags are coming from another repository, so we're don't know the ordering of tags
-                rv.extend([x['name'] for x in resp_data['results']])
-            # Page until there are no results left
-            url = resp_data.get('next', None)
-            if url is None:
+                tags.extend(tag_info.get('name') for tag_info in response_data['results'] if tag_info.get('name'))
+            url = response_data.get('next')
+            if not url:
+                logger.info("No more pages left to fetch.")
                 break
-        elif resp.status_code == 429:
-            # Based on https://docs.docker.com/docker-hub/api/latest/#tag/rate-limiting
-            # We've hit the rate limit so we have to wait and try again later
-            time.sleep(int(resp.headers['retry-after']) - int(time.time()))
-        else:
+        except requests.exceptions.HTTPError as e:
+            if response.status_code == 429:
+                # Based on https://docs.docker.com/docker-hub/api/latest/#tag/rate-limiting
+                # We've hit the rate limit so we have to wait and try again later
+                logger.warning("Rate limit reached for DockerHub. Retrying after sleep..")
+                time.sleep(int(response.headers['retry-after']) - int(time.time()))
+            else:
+                logger.error(f"HTTP error occurred: {e}")
             break
-
-    return rv
+        except requests.exceptions.ConnectionError as e:
+            logger.error(f"Connection error occurred: {e}")
+            break
+        except requests.exceptions.Timeout as e:
+            logger.error("Request timed out.")
+            break
+        except requests.exceptions.RequestException as e:
+            logger.error(f"An error occurred during requests: {e}")
+            break
+        except ValueError as e:
+            logger.error(f"JSON decode error: {e}")
+            break
+    if tags:
+        logger.info(f"Tags retrieved successfully: {tags}")
+    return tags


### PR DESCRIPTION
This patch will prioritize using system-based configurations for registry authentication then default to what's configured for the service.

It will also place the logic of retrieving the authentication into a common function that can be re-used by other components and won't rely on committing credentials back into the service in order to pull the tags or images from a container image registry.