### PR TITLE
Fix ttl and expiry time comparison

### DIFF
--- a/assemblyline_core/tasking_client.py
+++ b/assemblyline_core/tasking_client.py
@@ -8,7 +8,7 @@ from assemblyline.common import forge
 from assemblyline.common.constants import SERVICE_STATE_HASH, ServiceStatus
 from assemblyline.common.dict_utils import flatten, unflatten
 from assemblyline.common.heuristics import HeuristicHandler, InvalidHeuristicException
-from assemblyline.common.isotime import now_as_iso
+from assemblyline.common.isotime import now_as_iso, now_as_utc_datetime
 from assemblyline.common.threading import APMAwareThreadPoolExecutor
 from assemblyline.datastore.helper import AssemblylineDatastore
 from assemblyline.filestore import FileStore
@@ -264,7 +264,7 @@ class TaskingClient:
                 result.archive_ts = None
 
                 if task.ttl and result.expiry_ts:
-                    result.expiry_ts = max(result.expiry_ts, now_as_iso(task.ttl * 24 * 60 * 60))
+                    result.expiry_ts = max(result.expiry_ts, now_as_utc_datetime(task.ttl * 24 * 60 * 60))
 
                 # Create a list of files to freshen
                 freshen_hashes = [task.fileinfo.sha256]


### PR DESCRIPTION
This is to fix issue https://github.com/CybercentreCanada/assemblyline/issues/241


### Reproducing the issue
I was able to reproduce the error described in the issue by setting **Result Caching** to `true` and set a **Days to live** value.
```
    result.expiry_ts = max(result.expiry_ts, now_as_iso(task.ttl * 24 * 60 * 60))
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'datetime.datetime'
```


### The Fix
We are setting `expiry_ts` as a ISO timestamp string everywhere; however, when the `expiry_ts` object is stored in the Result class, it gets convert to datetime object instead. So the `result.expiry_ts` is a `datetime` object. The `now_as_iso` function returns a `string` object.
I created a new function in base to for a function that returns now as a `datetime` object.

