### PR TITLE
Module `re` imported but not used.

### DIFF
--- a/assemblyline_core/scaler/scaler_server.py
+++ b/assemblyline_core/scaler/scaler_server.py
@@ -8,7 +8,6 @@ from collections import defaultdict
 from string import Template
 from typing import Dict, Optional, Any
 import os
-import re
 import math
 import time
 import platform


### PR DESCRIPTION
```
pyflakes: error
're' imported but unused
```