### PR TITLE
Trigger a heartbeat to let the system know the workflow manager is still alive between tasks

### DIFF
--- a/assemblyline_core/workflow/run_workflow.py
+++ b/assemblyline_core/workflow/run_workflow.py
@@ -109,6 +109,9 @@ class WorkflowManager(ServerBase):
                     if not workflow.enabled:
                         continue
 
+                    # Trigger a heartbeat to let the system know the workflow manager is still alive between tasks
+                    self.heartbeat()
+
                     # Start of transaction
                     if self.apm_client:
                         self.apm_client.begin_transaction("Execute workflows")


### PR DESCRIPTION
Related to: https://cccs.atlassian.net/browse/AL-3065

Solves an issue where the probe will fail on instances of Assemblyline that contain many workflows and those workflows may not have very performant queries.