### PR TITLE
The start point of the Workflow component should be the oldest alert in a TRIAGE state

### DIFF
--- a/assemblyline_core/workflow/run_workflow.py
+++ b/assemblyline_core/workflow/run_workflow.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
 
-import elasticapm
 import time
 
-from assemblyline_core.server_base import ServerBase
+import elasticapm
 from assemblyline.common import forge
 from assemblyline.common.isotime import now_as_iso
 from assemblyline.common.str_utils import safe_str
-
 from assemblyline.datastore.exceptions import SearchException
 from assemblyline.odm.models.alert import Event
 from assemblyline.odm.models.workflow import Workflow
+
+from assemblyline_core.server_base import ServerBase
 
 
 class WorkflowManager(ServerBase):
@@ -19,7 +19,13 @@ class WorkflowManager(ServerBase):
 
         self.config = forge.get_config()
         self.datastore = forge.get_datastore(self.config)
-        self.start_ts = f"{self.datastore.ds.now}/{self.datastore.ds.day}-1{self.datastore.ds.day}"
+
+        # Get the earliest alert that has yet to have been triaged (or default to the last day)
+        alert = (self.datastore.alert.search("status:TRIAGE", sort='reporting_ts desc', rows=1,
+                                             fl='reporting_ts', as_obj=False)['items'] \
+                                                or \
+                                            [{'reporting_ts': 'now-1d/d'}])[0]
+        self.start_ts = alert['reporting_ts']
 
         if self.config.core.metrics.apm_server.server_url is not None:
             self.log.info(f"Exporting application metrics to: {self.config.core.metrics.apm_server.server_url}")

--- a/assemblyline_core/workflow/run_workflow.py
+++ b/assemblyline_core/workflow/run_workflow.py
@@ -21,7 +21,7 @@ class WorkflowManager(ServerBase):
         self.datastore = forge.get_datastore(self.config)
 
         # Get the earliest alert that has yet to have been triaged (or default to the last day)
-        alert = (self.datastore.alert.search("status:TRIAGE", sort='reporting_ts desc', rows=1,
+        alert = (self.datastore.alert.search("status:TRIAGE", sort='reporting_ts asc', rows=1,
                                              fl='reporting_ts', as_obj=False)['items'] \
                                                 or \
                                             [{'reporting_ts': 'now-1d/d'}])[0]

--- a/pipelines/azure-tests.yaml
+++ b/pipelines/azure-tests.yaml
@@ -35,10 +35,6 @@ jobs:
   - job: run_test
     strategy:
       matrix:
-        Python3_9:
-          python.version: "3.9"
-        Python3_10:
-          python.version: "3.10"
         Python3_11:
           python.version: "3.11"
         Python3_12:

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 
 import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 # Try to load the version from a datafile in the package
 package_version = "4.0.0.dev0"
@@ -30,10 +30,6 @@ setup(
         'Intended Audience :: Developers',
         'Topic :: Software Development :: Libraries',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
     ],

--- a/test/test_workflow.py
+++ b/test/test_workflow.py
@@ -1,11 +1,11 @@
-import pytest
 import random
-from assemblyline_core.workflow.run_workflow import WorkflowManager
 
-from assemblyline.common.isotime import now_as_iso
+import pytest
+from assemblyline.common.isotime import epoch_to_iso
 from assemblyline.odm.models.workflow import Workflow
 from assemblyline.odm.random_data import create_alerts, wipe_alerts, wipe_workflows
 from assemblyline.odm.randomizer import random_minimal_obj
+from assemblyline_core.workflow.run_workflow import WorkflowManager
 
 
 @pytest.fixture(scope="module")
@@ -13,7 +13,7 @@ def manager(datastore_connection):
     try:
         create_alerts(datastore_connection)
         wipe_workflows(datastore_connection)
-        datastore_connection.alert.update_by_query("*", [(datastore_connection.alert.UPDATE_SET, 'reporting_ts', now_as_iso())])
+        datastore_connection.alert.update_by_query("*", [(datastore_connection.alert.UPDATE_SET, 'reporting_ts', epoch_to_iso(0))])
         datastore_connection.alert.commit()
         yield WorkflowManager()
     finally:
@@ -23,12 +23,12 @@ def test_workflow(manager, datastore_connection):
     # Create workflow that targets alerts based on YARA rule association
     workflow = random_minimal_obj(Workflow)
 
-    yara_rule = random.choice(list(datastore_connection.alert.facet("al.yara").keys()))   
+    yara_rule = random.choice(list(datastore_connection.alert.facet("al.yara").keys()))
     workflow.query = f'al.yara:"{yara_rule}"'
     workflow.workflow_id = "AL_TEST"
     workflow.labels = ["AL_TEST"]
     workflow.priority = "LOW"
-    workflow.status = "MALICIOUS"    
+    workflow.status = "MALICIOUS"
     datastore_connection.workflow.save(workflow.workflow_id, workflow)
     datastore_connection.workflow.commit()
 
@@ -37,7 +37,7 @@ def test_workflow(manager, datastore_connection):
     manager.get_last_reporting_ts = lambda x: "now/d+1d"
     manager.try_run(run_once=True)
     datastore_connection.alert.commit()
-    
+
     # Assert that custom labels were applied to alerts
     assert datastore_connection.alert.search("label:AL_TEST", track_total_hits=True)['total']
 


### PR DESCRIPTION
If an alert's status is reset to TRIAGE or there's downtime for the Workflow component longer than a day, then at start-up it should use the earliest triage-ready alert as a starting point to perform automatic triage. 