### PR TITLE
Revert "Assemblyline/issues/445 (dev)"

### DIFF
--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -163,32 +163,9 @@ class HarborRegistry(ContainerRegistry):
         return []
 
 
-class JfrogRegistry(ContainerRegistry):
-    def _get_proprietary_registry_tags(self, server, image_name, auth, verify, proxies=None, token_server=None):
-        # Find latest tag for each types
-        # JFrog Artifactory Docker registry API: https://docs.jfrog.com/artifactory/reference/listDockerTags
-        # The repo key is derived from the first segment of the image name
-        repo_key, repo_path = image_name.split('/', 1)
-        url = f"https://{server}/artifactory/api/docker/{repo_key}/v2/{repo_path}/tags/list"
-
-        # Get tag list
-        headers = {}
-        if auth:
-            headers["Authorization"] = auth
-
-        resp = self._perform_request(url, headers, verify, proxies)
-
-        # Test for valid response
-        if resp and resp.ok:
-            resp_data = resp.json()
-            return resp_data['tags'] or []
-        return []
-
-
 REGISTRY_TYPE_MAPPING = {
     'docker': DockerRegistry(),
-    'harbor': HarborRegistry(),
-    'jfrog': JfrogRegistry()
+    'harbor': HarborRegistry()
 }
 
 def get_registry_config(docker_config: DockerConfig, system_config: SystemConfig) -> Dict[str, str]:


### PR DESCRIPTION
Reverts CybercentreCanada/assemblyline-core#1131

Reverting changes since the change is no longer necessary since JFrog registries supports [Docker Registry HTTP API V2](https://distribution.github.io/distribution/spec/api/) so the `docker` registry type can be used in AL:
https://discord.com/channels/908084610158714900/909869835041787924/1513910826455666938