### PR TITLE
Fix ACR tag pagination when fetching registry tags

### DIFF
--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -105,19 +105,16 @@ class AzureContainerRegistry(ContainerRegistry):
             resp_data = resp.json()
             tags.extend(resp_data.get('tags') or [])
 
-            # Follow the 'Link' header for pagination (RFC 5988), as documented by the Docker
-            # Registry HTTP API V2 spec. ACR caps each page at 1000 tags regardless of 'n', so
-            # repositories with more tags than that require multiple requests to retrieve them all.
-            link_header = resp.headers.get('Link')
-            if not link_header:
+            # Link header format: <https://{server}/v2/{image_name}/tags/list?n=1000&last=...>; rel="next"
+            next_link = resp.links.get("next")
+            if not next_link:
+                # If there's no next link, we've reached the last page of results
                 break
 
-            # Link header format: <https://{server}/v2/{image_name}/tags/list?n=1000&last=...>; rel="next"
-            link_match = re.match(r'<(?P<url>[^>]+)>', link_header)
-            if not link_match:
-                break
-            next_url = link_match.group('url')
+            # Prepare the next URL for the subsequent request. The 'next' link may be relative or absolute.
+            next_url = next_link["url"]
             if next_url.startswith('/'):
+                # Resolve relative URL to absolute URL if necessary
                 next_url = f"https://{server}{next_url}"
             resp = self._perform_request(next_url, headers, verify, proxies)
 

--- a/assemblyline_core/updater/helper.py
+++ b/assemblyline_core/updater/helper.py
@@ -70,7 +70,13 @@ class DockerRegistry(ContainerRegistry):
 class AzureContainerRegistry(ContainerRegistry):
     def _get_proprietary_registry_tags(self, server, image_name, auth, verify, proxies=None, token_server=None):
         # Find latest tag for each types
-        url = f"https://{server}/v2/{image_name}/tags/list"
+        # Explicitly request the maximum page size (1000) supported by ACR. Without the 'n' parameter,
+        # ACR defaults to only 100 tags per page, alphabetically sorted (not by push date/time).
+        # Repositories with more tags than the page size (e.g. long-running services with nightly
+        # builds) would silently have their most recent tags dropped if pagination isn't followed,
+        # since lexicographic ordering of variable-length build numbers doesn't match numeric order
+        # (e.g. "100" sorts before "99").
+        url = f"https://{server}/v2/{image_name}/tags/list?n=1000"
 
         # Get tag list
         headers = {}
@@ -94,12 +100,28 @@ class AzureContainerRegistry(ContainerRegistry):
                 resp = self._perform_request(url, headers, verify, proxies)
 
         # At this point, we should have a response from the API
-        if resp and resp.ok:
-            # Test for positive list of tags
+        tags = []
+        while resp and resp.ok:
             resp_data = resp.json()
-            return resp_data['tags'] or []
+            tags.extend(resp_data.get('tags') or [])
 
-        return []
+            # Follow the 'Link' header for pagination (RFC 5988), as documented by the Docker
+            # Registry HTTP API V2 spec. ACR caps each page at 1000 tags regardless of 'n', so
+            # repositories with more tags than that require multiple requests to retrieve them all.
+            link_header = resp.headers.get('Link')
+            if not link_header:
+                break
+
+            # Link header format: <https://{server}/v2/{image_name}/tags/list?n=1000&last=...>; rel="next"
+            link_match = re.match(r'<(?P<url>[^>]+)>', link_header)
+            if not link_match:
+                break
+            next_url = link_match.group('url')
+            if next_url.startswith('/'):
+                next_url = f"https://{server}{next_url}"
+            resp = self._perform_request(next_url, headers, verify, proxies)
+
+        return tags
 
 class GitHubContainerRegistry(ContainerRegistry):
     def _get_proprietary_registry_tags(self, server, image_name, auth, verify, proxies=None, token_server=None):
@@ -300,6 +322,8 @@ def get_latest_tag_for_service(service_config: ServiceConfig, system_config: Sys
         tags = registry._get_proprietary_registry_tags(server, image_name, auth,
                                                        not system_config.services.allow_insecure_registry,
                                                        proxies, token_server)
+        logger.info(f"{prefix}Fetched {len(tags)} raw tag(s) for service {service_name} - {image_name} "
+                f"from {server} before filtering.")
     # Pre-filter tags to only consider 'compatible' tags relative to the running system
     tags = [tag for tag in tags
             if re.match(f"({FRAMEWORK_VERSION})\\.({SYSTEM_VERSION})\\.\\d+\\.({update_channel})\\d+", tag)]

--- a/test/test_updater_helper.py
+++ b/test/test_updater_helper.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock, patch
+
+from assemblyline_core.updater.helper import AzureContainerRegistry
+
+
+SERVER = "registry.example"
+IMAGE_NAME = "namespace/service"
+FIRST_PAGE_URL = f"https://{SERVER}/v2/{IMAGE_NAME}/tags/list?n=1000"
+NEXT_PAGE_URL = f"https://{SERVER}/v2/{IMAGE_NAME}/tags/list?n=1000&last=tag-b"
+
+
+def _make_response(tags, link_header=None):
+    resp = MagicMock()
+    resp.ok = True
+    resp.json.return_value = {"tags": tags}
+    resp.headers = {"Link": link_header} if link_header else {}
+    return resp
+
+
+def test_azure_registry_follows_pagination_links():
+    first_page = _make_response(
+        ["tag-a", "tag-b"],
+        link_header=f'<{NEXT_PAGE_URL}>; rel="next"',
+    )
+    second_page = _make_response(["tag-c"], link_header=None)
+    requested_urls = []
+
+    def fake_get(url, headers=None, verify=None, proxies=None):
+        requested_urls.append(url)
+        if url == FIRST_PAGE_URL:
+            return first_page
+        if url == NEXT_PAGE_URL:
+            return second_page
+        raise AssertionError(f"Unexpected URL requested: {url}")
+
+    registry = AzureContainerRegistry()
+    with patch("assemblyline_core.updater.helper.requests.get", side_effect=fake_get):
+        tags = registry._get_proprietary_registry_tags(
+            server=SERVER, image_name=IMAGE_NAME, auth="Bearer token", verify=True
+        )
+
+    assert tags == ["tag-a", "tag-b", "tag-c"]
+    assert requested_urls == [FIRST_PAGE_URL, NEXT_PAGE_URL]

--- a/test/test_updater_helper.py
+++ b/test/test_updater_helper.py
@@ -2,27 +2,31 @@ from unittest.mock import MagicMock, patch
 
 from assemblyline_core.updater.helper import AzureContainerRegistry
 
-
 SERVER = "registry.example"
 IMAGE_NAME = "namespace/service"
 FIRST_PAGE_URL = f"https://{SERVER}/v2/{IMAGE_NAME}/tags/list?n=1000"
 NEXT_PAGE_URL = f"https://{SERVER}/v2/{IMAGE_NAME}/tags/list?n=1000&last=tag-b"
 
 
-def _make_response(tags, link_header=None):
+def _make_response(tags, links=None):
     resp = MagicMock()
     resp.ok = True
     resp.json.return_value = {"tags": tags}
-    resp.headers = {"Link": link_header} if link_header else {}
+    resp.links = links or {}
     return resp
 
 
 def test_azure_registry_follows_pagination_links():
     first_page = _make_response(
         ["tag-a", "tag-b"],
-        link_header=f'<{NEXT_PAGE_URL}>; rel="next"',
+        links= {
+            'next': {
+                'url': NEXT_PAGE_URL,
+                'rel': 'next'
+            }
+        }
     )
-    second_page = _make_response(["tag-c"], link_header=None)
+    second_page = _make_response(["tag-c"], links=None)
     requested_urls = []
 
     def fake_get(url, headers=None, verify=None, proxies=None):


### PR DESCRIPTION
## Summary

Fixes Azure Container Registry tag retrieval so repositories with more than one page of tags are handled correctly.

The updater now:
- requests the maximum ACR tag page size with `n=1000`
- follows the registry `Link` pagination header
- combines tags from all returned pages before selecting the latest compatible tag
- logs raw and filtered tag counts to make tag-selection issues easier to diagnose

## Testing

Added a regression test covering multi-page ACR tag responses and pagination via the `Link` header.

```bash
python -m pytest test/test_updater_helper.py -q